### PR TITLE
Add support for zip archive type for Windows and macOS

### DIFF
--- a/lib/sqldef.rb
+++ b/lib/sqldef.rb
@@ -130,7 +130,7 @@ module Sqldef
       archive = OS_ARCHIVE.fetch(os)
       arch = Etc.uname.fetch(:machine)
       goarch = GOARCH.fetch(arch, arch)
-      "https://github.com/k0kubun/sqldef/releases/latest/download/#{command}_#{os}_#{goarch}.#{archive}"
+      "https://github.com/sqldef/sqldef/releases/latest/download/#{command}_#{os}_#{goarch}.#{archive}"
     end
 
     # TODO: Retry transient errors

--- a/sqldef.gemspec
+++ b/sqldef.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |spec|
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = spec.homepage
 
+  spec.add_runtime_dependency 'rubyzip'
+
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path(__dir__)) do


### PR DESCRIPTION
I installed https://github.com/sqldef/sqldef-rails and ran `bundle exec rake db:schema:dump` today. It caused errors due to following 3 reasons:

* `Etc.uname == 'arm64'` is not expected. Error message:
```
KeyError: key not found: "arm64"
```

* sqldef repository is moved from k0kubun to sqldef on github. Thus GitHub made one additional redirect. Error message:
```
Expected 'https://github.com/k0kubun/sqldef/releases/latest/download/psqldef_darwin_arm64.zip' to return 302, but got 301:
```

* Binary releases are archived in zip format for windows and darwin. Error message:
```
Zlib::GzipFile::Error: not in gzip format
```

This PR fixes the errors and makes the sqldef-rails working on macOS.

Environment:
* macOS 12.7.2
* MacBook Pro, Apple M1
* Output of `uname -m`:
```
$ uname -m
arm64
$ which uname
/opt/homebrew/opt/coreutils/libexec/gnubin/uname
$ /usr/bin/uname -m
arm64
```
